### PR TITLE
Add restart interval

### DIFF
--- a/service/deployer_mitreid.service
+++ b/service/deployer_mitreid.service
@@ -5,6 +5,7 @@ Description=MitreId deployer service
 User=root
 ExecStart={{venv_path}/deployer_mitreid -c /etc/conf/deployer_mitreid.config 
 Restart=always
+RestartSec=60s
 Type=simple
 
 [Install]

--- a/service/deployer_ssp.service
+++ b/service/deployer_ssp.service
@@ -5,6 +5,7 @@ Description=Satosa deployer service
 User=root
 ExecStart={{venv_path}/deployer_ssp -c /etc/conf/deployer_ssp.config 
 Restart=always
+RestartSec=60s
 Type=simple
 
 [Install]


### PR DESCRIPTION
Add restart interval in the service files as this caused problem when the deployers were exiting with an error.
The problem was that the service tried to restart too soon and caused the service to crash