### PR TITLE
Decode to utf-8 data before loading with json

### DIFF
--- a/ServiceRegistryAms/PullPublish.py
+++ b/ServiceRegistryAms/PullPublish.py
@@ -26,7 +26,7 @@ class PullPublish():
             data = msg.get_data()
             msgid = msg.get_msgid()
             attr = msg.get_attr()
-            messages.append(json.loads(data))
+            messages.append(json.loads(data.decode("utf-8")))
             #print('msgid={0}, data={1}, attr={2}'.format(msgid, data, attr))
             ackids.append(id)
         return messages, ackids


### PR DESCRIPTION
This change is required for the script to be compatible with python 3.5. https://docs.python.org/3/whatsnew/3.6.html#json

In newer python versions the json.loads handles binary input automatically.