### PR TITLE
Return client_id value on create and on edit for mitreid

### DIFF
--- a/Utils/common.py
+++ b/Utils/common.py
@@ -12,13 +12,16 @@ def get_log_conf(log_config_file=None):
 
 # create_ams_response creates a json object with the result of the mitreId api call
 # that is readable from the rciam-federation-registry
-def create_ams_response(response, service_id, agent_id, external_id):
+def create_ams_response(response, service_id, agent_id, external_id, client_id):
     msgNew = {}
     msgNew['id'] = service_id
     msgNew['agent_id'] = agent_id
     msgNew['status_code'] = response['status']
     if external_id>0:
         msgNew['external_id'] = external_id
+
+    if len(client_id)>0:
+        msgNew['client_id'] = client_id
 
     if response['status'] != 200:
         msgNew['error_description'] = response['error']

--- a/bin/deployer_mitreid
+++ b/bin/deployer_mitreid
@@ -67,13 +67,14 @@ def update_data(messages, issuer_url, access_token, agent_id):
         log.debug('Message from ams: ' + str(msg))
         service_id = msg.pop('id')    # Remove rciam service id to make request to mitreId
         external_id = -1
+        client_id = ''
         try:
-            response, external_id = call_mitreid(msg, mitreid_agent)
+            response, external_id, client_id = call_mitreid(msg, mitreid_agent)
             log.info('Message received from mitreId: ' + str(response))
-            ams_message = create_ams_response(response, service_id, agent_id, external_id)
+            ams_message = create_ams_response(response, service_id, agent_id, external_id, client_id)
         except:
             log.critical('Exception catch, return error to ams')
-            ams_message = create_ams_response({'status': 0,'error': 'An error occurred while calling mitreId'}, service_id, agent_id, external_id)
+            ams_message = create_ams_response({'status': 0,'error': 'An error occurred while calling mitreId'}, service_id, agent_id, external_id, client_id)
         pub_messages.append({'attributes':{},'data':ams_message})
     return pub_messages
 
@@ -99,11 +100,13 @@ def call_mitreid(registry_message,mitreid_agent):
     log.debug('Formated message for mitreId: ' + str(mitreid_msg))
     response = {}
     external_id = -1
+    client_id = ''
     if deployment_type == 'create':
         log.info('Create new client')
         response = mitreid_agent.createClient(mitreid_msg)
         if (response['status']==200):
             external_id = response['response']['id']
+            client_id = response['response']['clientId']
     elif deployment_type == 'delete':
         external_id = registry_message['external_id']
         log.info('Delete client with id: ' + str(external_id))
@@ -112,7 +115,9 @@ def call_mitreid(registry_message,mitreid_agent):
         external_id = registry_message['external_id']
         log.info('Update client with id: ' + str(external_id))
         response = mitreid_agent.updateClientById(registry_message['external_id'], mitreid_msg)
-    return response, external_id
+        if (response['status']==200):
+            client_id = response['response']['clientId']
+    return response, external_id, client_id
 
 
 if __name__ == '__main__':

--- a/bin/deployer_ssp
+++ b/bin/deployer_ssp
@@ -98,7 +98,7 @@ def call_ssp_syncer(ssp_url, metadata_key, request_timeout):
 def publish_ams(ams_agent, response, messages, agent_id):
     pub_messages = []
     for message in messages:
-        msg = create_ams_response(response, message['id'], agent_id, -1)
+        msg = create_ams_response(response, message['id'], agent_id, -1, '')
         pub_messages.append({'attributes':{},'data': msg})
     print(pub_messages)
     ams_agent.publish(pub_messages)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     name='rciam-federation-registry-agent',
     author='grnet',
     author_email='faai@grnet.gr',
-    version='1.2.1',
+    version='1.3.0',
     license='ASL 2.0',
     url='https://github.com/rciam/rciam-federation-registry-agent',
     packages=find_packages(),


### PR DESCRIPTION
Return client id to registry for mitreid deployer.
This is for the case that a registry do not provide a client_id then the mitreid auto generates one and we need to store it to rciam-registry