### PR TITLE
Add token timeout mapping

### DIFF
--- a/bin/deployer_mitreid
+++ b/bin/deployer_mitreid
@@ -37,6 +37,7 @@ def format_mitreid_msg(msg):
     msgNew['contacts'] = emails
     msgNew['clientName'] = msgNew.pop('serviceName')
     msgNew['clientDescription'] = msgNew.pop('serviceDescription')
+    msgNew['idTokenValiditySeconds'] = msgNew.pop('idTokenTimeoutSeconds')
     if 'externalId' in msgNew:
         msgNew.pop('externalId')
     if 'tokenEndpointAuthMethod' in msgNew:


### PR DESCRIPTION
Add mapping for token timeout because the rciam federation uses `idTokenTimeoutSeconds` which is different than the mitreid expected value `idTokenValiditySeconds`