### PR TITLE
Mitreid: map website_url and aup_url

### DIFF
--- a/bin/deployer_mitreid
+++ b/bin/deployer_mitreid
@@ -41,6 +41,10 @@ def format_mitreid_msg(msg):
         msgNew.pop('externalId')
     if 'tokenEndpointAuthMethod' in msgNew:
         msgNew['tokenEndpointAuthMethod'] = map_token_endpoint_value(msgNew['tokenEndpointAuthMethod'])
+    if 'aupUri' in msgNew:
+        msgNew['tosUri'] = msgNew.pop('aupUri')
+    if 'websiteUrl' in msgNew:
+        msgNew['clientUri'] = msgNew.pop('websiteUrl')
     return msgNew
 
 


### PR DESCRIPTION
Mapping website_url and aup_url to clientUri and tosUri respectively. 
Fist check if the field exists in the message received from Rciam-registry and then replace it as shown bellow. 