### PR TITLE
Fix keycloak deployer client options

### DIFF
--- a/bin/deployer_keycloak
+++ b/bin/deployer_keycloak
@@ -13,7 +13,7 @@ from Utils.oauth import clientCredentialsGrant, refreshTokenGrant
 log = logging.getLogger(__name__)
 
 # Set default JSON Data
-jsonTemplate = '{"attributes":{"client_credentials.use_refresh_token":"false","oauth2.device.authorization.grant.enabled":"false","oauth2.token.exchange.grant.enabled":false,"oidc.ciba.grant.enabled":"false","refresh.token.max.reuse":"0","revoke.refresh.token":"false","use.jwks.string":"false","use.jwks.url":"false","use.refresh.tokens":"false"},"consentRequired":true,"implicitFlowEnabled":false,"publicClient":false,"serviceAccountsEnabled":false,"standardFlowEnabled":false}'
+jsonTemplate = '{"attributes":{"client_credentials.use_refresh_token":"false","oauth2.device.authorization.grant.enabled":"false","oauth2.token.exchange.grant.enabled":false,"oidc.ciba.grant.enabled":"false","refresh.token.max.reuse":"0","revoke.refresh.token":"false","use.jwks.string":"false","use.jwks.url":"false","use.refresh.tokens":"false"},"consentRequired":false,"implicitFlowEnabled":false,"publicClient":false,"serviceAccountsEnabled":false,"standardFlowEnabled":false}'
 
 
 def map_token_endpoint_value(key):
@@ -106,6 +106,8 @@ def format_keycloak_msg(msg, realm_default_client_scopes):
         new_msg["attributes"]["id.token.lifespan"] = str(msg.pop("id_token_timeout_seconds"))
     if "device_code_validity_seconds" in msg:
         new_msg["attributes"]["oauth2.device.code.lifespan"] = str(msg.pop("device_code_validity_seconds"))
+    if new_msg["standardFlowEnabled"] == True or new_msg["attributes"]["oauth2.device.authorization.grant.enabled"] == True:
+        new_msg["consentRequired"] = True
     return new_msg
 
 

--- a/bin/deployer_keycloak
+++ b/bin/deployer_keycloak
@@ -92,7 +92,6 @@ def format_keycloak_msg(msg, realm_default_client_scopes):
         new_msg["attributes"]["jwks.url"] = msg.pop("jwks_uri")
     if "refresh_token_validity_seconds" in msg:
         new_msg["attributes"]["client.offline.session.idle.timeout"] = str(msg["refresh_token_validity_seconds"])
-        new_msg["attributes"]["client.offline.session.max.lifespan"] = str(msg.pop("refresh_token_validity_seconds"))
         if "reuse_refresh_token" in msg:
             rotate_refresh_token = str(not msg.pop("reuse_refresh_token"))
             new_msg["attributes"]["revoke.refresh.token"] = rotate_refresh_token.lower()

--- a/bin/deployer_keycloak
+++ b/bin/deployer_keycloak
@@ -159,6 +159,28 @@ def publish_ams(pub_messages, ams_agent):
         log.debug("Messages published to ams: " + str(pub_messages))
         ams_agent.publish(pub_messages)
 
+# Create the optional client scopes of the client
+def create_client_scopes(agent, client_uuid, client_config):
+    realm_client_scopes = agent.sync_realm_client_scopes()
+    new_optional_client_scopes = client_config["optionalClientScopes"]
+
+    # Custom scopes that are not created in Keycloak
+    create_client_scopes = list(set(new_optional_client_scopes) - set(realm_client_scopes.keys()))
+    parametric_scope_delimiter = "?value="
+    for scope in create_client_scopes:
+        if parametric_scope_delimiter in scope:
+            # Ignore parametric scopes
+            log.info("The scope '" + scope + "' will be ignored.")
+            new_optional_client_scopes.remove(scope)
+        else:
+            # Create custom scope
+            agent.create_realm_client_scopes(scope)
+
+    # Get updated client scopes
+    realm_client_scopes = agent.sync_realm_client_scopes()
+
+    for add_scope in create_client_scopes:
+        agent.add_client_scope_by_id(client_uuid, realm_client_scopes[add_scope])
 
 # Update the optional client scopes of the client
 def update_client_scopes(agent, client_uuid, new_client_config, current_client_config):
@@ -223,6 +245,7 @@ def call_keycloak(registry_message, keycloak_agent, keycloak_config):
             else:
                 response_external_id = keycloak_agent.get_client_by_id(client_id)
                 external_id = response_external_id["response"]["id"]
+        create_client_scopes(keycloak_agent, external_id, keycloak_msg)
         if keycloak_msg["attributes"]["oauth2.token.exchange.grant.enabled"] == True:
             keycloak_agent.update_client_authz_permissions(external_id, "enable")
         if response["response"]["serviceAccountsEnabled"]:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     name='rciam-federation-registry-agent',
     author='grnet',
     author_email='faai@grnet.gr',
-    version='2.3.1',
+    version='2.3.2',
     license='ASL 2.0',
     url='https://github.com/rciam/rciam-federation-registry-agent',
     packages=find_packages(),


### PR DESCRIPTION
This PR introduces the following changes:

- Ignore `client.offline.session.max.lifespan` parameter
- Enable consent page only if the authZ code or device code flow is enabled
- Create custom scopes during client creation
