### PR TITLE
Remove deprecated update_client_authz_permission calls in edit requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The main standalone deployment scripts are located under `bin/`:
 
 ---
 
+## [4.0.2] - 2026-02-24
+
+### Fixed
+- Removed depricated update_client_authz_permission calls in edit requests 
+
+
 ## [4.0.1] - 2026-02-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The main standalone deployment scripts are located under `bin/`:
 ## [4.0.2] - 2026-02-24
 
 ### Fixed
-- Removed depricated update_client_authz_permission calls in edit requests 
+- Removed deprecated update_client_authz_permission calls in edit requests 
 
 
 ## [4.0.1] - 2026-02-19

--- a/bin/deployer_keycloak
+++ b/bin/deployer_keycloak
@@ -334,17 +334,6 @@ def deploy_to_keycloak(registry_message, keycloak_agent, keycloak_config):
                 update_service_account(
                     keycloak_agent, external_id, response["response"], keycloak_config["service_account"]
                 )
-            client_authz_permissions_response = keycloak_agent.get_client_authz_permissions(external_id)
-            if (
-                client_authz_permissions_response["response"]["enabled"] == False
-                and keycloak_msg["attributes"]["standard.token.exchange.enabled"] == True
-            ):
-                keycloak_agent.update_client_authz_permissions(external_id, "enable")
-            elif (
-                client_authz_permissions_response["response"]["enabled"] == True
-                and keycloak_msg["attributes"]["standard.token.exchange.enabled"] == False
-            ):
-                keycloak_agent.update_client_authz_permissions(external_id, "disable")
         if protocol == "saml":
             update_client_scopes(keycloak_agent, external_id, keycloak_msg, response["response"])
     return response, external_id, client_id

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     name="rciam-federation-registry-agent",
     author="grnet",
     author_email="faai@grnet.gr",
-    version="4.0.1",
+    version="4.0.2",
     license="ASL 2.0",
     url="https://github.com/rciam/rciam-federation-registry-agent",
     packages=find_packages(),


### PR DESCRIPTION
The client authorisation permissions feature is not required for enabling/disabling the Token Exchange grant in Keycloak v26 or above